### PR TITLE
fix: scrape album-like playlists

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,7 +42,7 @@ async function fetchFromPlaylist(url: string) : Promise<YTPlaylist> {
         throw Error('Cannot find valid playlist JSON data. Is the playlist ID correct?');
     let listData = ytInitialData.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer;
     let d = ytInitialData;
-    
+
     let contToken: string = listData?.contents?.slice(-1)?.[0]?.continuationItemRenderer?.continuationEndpoint?.continuationCommand?.token || '';
     if(listData.contents)
         videos.push(...parseVideosFromJson(listData.contents));
@@ -52,7 +52,7 @@ async function fetchFromPlaylist(url: string) : Promise<YTPlaylist> {
     try {
         let mf = d.microformat.microformatDataRenderer;
         let si0 = d.sidebar.playlistSidebarRenderer.items[0].playlistSidebarPrimaryInfoRenderer;
-        let si1 = d.sidebar.playlistSidebarRenderer.items[1].playlistSidebarSecondaryInfoRenderer.videoOwner.videoOwnerRenderer;
+        let si1 = d.sidebar.playlistSidebarRenderer.items[1]?.playlistSidebarSecondaryInfoRenderer.videoOwner.videoOwnerRenderer;
         return {
             title: mf.title,
             url: baseURL + '/playlist?list=' + listData.playlistId,
@@ -62,15 +62,16 @@ async function fetchFromPlaylist(url: string) : Promise<YTPlaylist> {
             description: mf.description,
             isUnlisted: mf.unlisted,
             thumbnail_url: mf.thumbnail.thumbnails.pop().url.replace(/\?.*/, ''),
-            author: {
+            author: si1 ? {
                 name: si1.title.runs[0].text,
                 url: baseURL + si1.title.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url,
                 avatar_url: si1.thumbnail.thumbnails.pop().url
-            },
+            } : undefined,
             videos: videos
         }
     } catch(e) {
-        throw Error('Could not parse playlist metadata: ' + e.message);
+        if (e instanceof Error) throw Error('Could not parse playlist metadata: ' + e.message);
+        throw Error('Could not parse playlist metadata');
     }
 }
 

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -7,7 +7,7 @@ export interface YTPlaylist {
     description: string
     isUnlisted: boolean
     thumbnail_url: string
-    author: {
+    author?: {
         name: string
         url: string
         avatar_url: string

--- a/test/misc/properOutput.json
+++ b/test/misc/properOutput.json
@@ -9,7 +9,7 @@
   "author": {
     "name": "アヌス",
     "url": "https://www.youtube.com/user/CairoPl",
-    "avatar_url": "https://yt3.ggpht.com/ytc/AAUvwnhmmys8bepW7NpQPYQNRodQrgMwNzrgBn-uBxS6=s176-c-k-c0x00ffffff-no-rj"
+    "avatar_url": "https://yt3.ggpht.com/ytc/AKedOLSWzNdncoPdCV9F0RVWzjiZJcd58IF0AQqKYw4k=s176-c-k-c0x00ffffff-no-rj"
   },
   "videos": [
     {

--- a/test/misc/prophecyOutput.json
+++ b/test/misc/prophecyOutput.json
@@ -1,0 +1,156 @@
+{
+    "title": "The Prophecy",
+    "url": "https://www.youtube.com/playlist?list=OLAK5uy_mPFpBY7OwJ9mFvKxWKzSDJUXNKY9YXjOA",
+    "id": "OLAK5uy_mPFpBY7OwJ9mFvKxWKzSDJUXNKY9YXjOA",
+    "video_count": 12,
+    "view_count": 267288,
+    "description": "",
+    "isUnlisted": false,
+    "thumbnail_url": "https://i9.ytimg.com/s_p/OLAK5uy_mPFpBY7OwJ9mFvKxWKzSDJUXNKY9YXjOA/maxresdefault.jpg",
+    "videos": [
+        {
+            "title": "Intro (The)",
+            "url": "https://www.youtube.com/watch?v=cQw5CqIK_NA",
+            "id": "cQw5CqIK_NA",
+            "length": "1:12",
+            "milis_length": 72000,
+            "thumbnail_url": "https://i.ytimg.com/vi/cQw5CqIK_NA/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "The Mystic Crystal",
+            "url": "https://www.youtube.com/watch?v=kElj7EENGI4",
+            "id": "kElj7EENGI4",
+            "length": "11:55",
+            "milis_length": 715000,
+            "thumbnail_url": "https://i.ytimg.com/vi/kElj7EENGI4/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "It's Bedtime - NSP",
+            "url": "https://www.youtube.com/watch?v=MjPIbxFJdwg",
+            "id": "MjPIbxFJdwg",
+            "length": "3:16",
+            "milis_length": 196000,
+            "thumbnail_url": "https://i.ytimg.com/vi/MjPIbxFJdwg/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "The Wishing Bear",
+            "url": "https://www.youtube.com/watch?v=509cuhwjsNA",
+            "id": "509cuhwjsNA",
+            "length": "0:53",
+            "milis_length": 53000,
+            "thumbnail_url": "https://i.ytimg.com/vi/509cuhwjsNA/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "I Don't Know What We're Talking About - NSP",
+            "url": "https://www.youtube.com/watch?v=YhOadP3i3a8",
+            "id": "YhOadP3i3a8",
+            "length": "3:46",
+            "milis_length": 226000,
+            "thumbnail_url": "https://i.ytimg.com/vi/YhOadP3i3a8/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Welcome To My Parents' House - NSP",
+            "url": "https://www.youtube.com/watch?v=3YXUWWZJXpE",
+            "id": "3YXUWWZJXpE",
+            "length": "3:56",
+            "milis_length": 236000,
+            "thumbnail_url": "https://i.ytimg.com/vi/3YXUWWZJXpE/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Wondering Tonight - NSP",
+            "url": "https://www.youtube.com/watch?v=Dh3CddzpgYo",
+            "id": "Dh3CddzpgYo",
+            "length": "3:30",
+            "milis_length": 210000,
+            "thumbnail_url": "https://i.ytimg.com/vi/Dh3CddzpgYo/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Ninja Brian's Kids' album",
+            "url": "https://www.youtube.com/watch?v=tyixW91t4Po",
+            "id": "tyixW91t4Po",
+            "length": "0:21",
+            "milis_length": 21000,
+            "thumbnail_url": "https://i.ytimg.com/vi/tyixW91t4Po/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "The Decision Part 2: Ten Years Later - NSP",
+            "url": "https://www.youtube.com/watch?v=oufFWs7TuGI",
+            "id": "oufFWs7TuGI",
+            "length": "3:31",
+            "milis_length": 211000,
+            "thumbnail_url": "https://i.ytimg.com/vi/oufFWs7TuGI/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Do Math with U",
+            "url": "https://www.youtube.com/watch?v=29AP9ty5CKM",
+            "id": "29AP9ty5CKM",
+            "length": "3:55",
+            "milis_length": 235000,
+            "thumbnail_url": "https://i.ytimg.com/vi/29AP9ty5CKM/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Thunder & Lightning - NSP",
+            "url": "https://www.youtube.com/watch?v=-rSGoP5iGZQ",
+            "id": "-rSGoP5iGZQ",
+            "length": "3:16",
+            "milis_length": 196000,
+            "thumbnail_url": "https://i.ytimg.com/vi/-rSGoP5iGZQ/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        },
+        {
+            "title": "Outro (Prophecy)",
+            "url": "https://www.youtube.com/watch?v=qcWJ-sbPHOs",
+            "id": "qcWJ-sbPHOs",
+            "length": "0:23",
+            "milis_length": 23000,
+            "thumbnail_url": "https://i.ytimg.com/vi/qcWJ-sbPHOs/hqdefault.jpg",
+            "author": {
+                "name": "Ninja Sex Party",
+                "url": "https://www.youtube.com/channel/UCs7yDP7KWrh0wd_4qbDP32g"
+            }
+        }
+    ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,10 @@ const privatePlaylist = 'PLXJzeXpFb-pA-qXwgH2JdpYIx8lg8y4FW';
 const top500Playlist = 'PLAbeRqyTx1rIGWY13HgPyh0VF0LdoTQFp';
 const myTestList = 'PLXJzeXpFb-pDFQSy6EK7JEFRM1b8I1TTW';
 
+const prophecyTestList = 'OLAK5uy_mPFpBY7OwJ9mFvKxWKzSDJUXNKY9YXjOA';
+
 const properResult = JSON.parse(fs.readFileSync('test/misc/properOutput.json'));
+const prophecyProperResult = JSON.parse(fs.readFileSync('test/misc/prophecyOutput.json'));
 
 describe("ytfps", function() {
     this.timeout(30000);
@@ -26,5 +29,11 @@ describe("ytfps", function() {
 
     it('should throw private playlist error', async () => {
         await expect(ytfps(privatePlaylist)).to.be.rejectedWith('This playlist is private');
+    });
+
+    it('should be able to read nsp list', async () => {
+        let playlist = await ytfps(prophecyTestList);
+        for(let prop in prophecyProperResult)
+            expect(playlist[prop]).to.deep.eq(prophecyProperResult[prop]);
     });
 });


### PR DESCRIPTION
fixes #3 

This just checks wether `si1` is existent, otherwise we cannot retrieve author data for the playlist. That's why I had to change the Playlist Interface (author is now optional).

I also changed properOutput, because the test was not passing on my machine.
And I also added tests for the playlist that didn't work