### PR TITLE
fix: si1.title.runs is undefined

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,7 +68,9 @@ async function fetchFromPlaylist(url: string, opts: YTFPSOptions = {}) : Promise
             isUnlisted: mf.unlisted,
             isAlbum: 'albumName' in d.metadata.playlistMetadataRenderer,
             thumbnail_url: mf.thumbnail.thumbnails.pop().url.replace(/(?:&v=|&days).*/, ''),
-            author: si1 && {
+            author: si1 &&
+                si1.title.runs //some times there is no "runs" key - instead has direct title.simpleText
+                && {
                 name: si1.title.runs[0].text,
                 url: baseURL + si1.title.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url,
                 avatar_url: si1.thumbnail.thumbnails.pop().url


### PR DESCRIPTION
### The problem:
- For some playlist itseems that there is no "runs" key (array), instead a plain si1.title.simpleText



### Assumption:
 I think its for playlist with multiple owners / editors / cloab, its just doesnt  list all of them and has value of "מאת קהילת נייטפול ועוד 2 נוספים" (in english its someting like: "from {owner name} and 2 more"),

it seems that the "2 more" names / data doesnt included in the si1 which looks like so:
```ts
si1 = {
   "navigationEndpoint": {
      "clickTrackingParams": "CAQQ4TkiEwilhL2W2rGJAxWj6kkHHVRfIJ4="
   },
   "clickTrackingParams": "CAQQ4TkiEwilhL2W2rGJAxWj6kkHHVRfIJ4=",
   "thumbnail": [
      {
         "url": "https://yt3.ggpht.com/ntZL3Z9iRrDCQPf4tVnKTwPp…lSAAFsWpqJs98DJQPaGY=s48-c-k-c0x00ffffff-no-rj",
         "width": 48,
         "height": 48
      },
      {
         "url": "https://yt3.ggpht.com/ntZL3Z9iRrDCQPf4tVnKTwPp…lSAAFsWpqJs98DJQPaGY=s88-c-k-c0x00ffffff-no-rj",
         "width": 88,
         "height": 88
      },
      {
         "url": "https://yt3.ggpht.com/ntZL3Z9iRrDCQPf4tVnKTwPp…SAAFsWpqJs98DJQPaGY=s176-c-k-c0x00ffffff-no-rj",
         "width": 176,
         "height": 176
      }
   ],
   "title": {
      "simpleText": "by קהילת נייטפול and 1 other"
   }
}
```

> NOTE2: tested on the playlist: PLGTZ8tGofCCHQ_T_U9TsdmFw6LGcyGQvO